### PR TITLE
Add copy-to-clipboard button for CLI commands

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,15 +1,39 @@
 import { useState } from 'react';
 
-export default function CopyButton({ text }: { text: string }) {
+interface CopyButtonProps {
+  text: string;
+  compact?: boolean;
+}
+
+export default function CopyButton({ text, compact }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    if (navigator.clipboard) {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
+
+  if (compact) {
+    return (
+      <button
+        onClick={handleCopy}
+        className="shrink-0 p-1.5 rounded-md text-[var(--text-muted)] hover:text-[var(--accent-cyan)] hover:bg-[var(--bg-surface)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--accent-violet)]"
+        aria-label={copied ? 'Copied' : 'Copy command to clipboard'}
+        title={copied ? 'Copied!' : 'Copy'}
+      >
+        {copied ? (
+          <svg className="w-4 h-4 text-[var(--status-good)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        ) : (
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        )}
+      </button>
+    );
+  }
 
   return (
     <button

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import type { ChartView } from '@/components/DriftChart';
 import FilterPanel from '@/components/FilterPanel';
 import type { Filters } from '@/components/FilterPanel';
 import Button from '@/components/Button';
+import CopyButton from '@/components/CopyButton';
 import type { ChartDataPoint, ChartApiResponse } from '@/lib/types';
 import { aggregateByGranularity } from '@/lib/aggregate';
 
@@ -191,9 +192,12 @@ export default function Home() {
             <p className="text-[var(--text-secondary)] text-sm mb-3">
               No eval submissions found. Start submitting results from the CLI:
             </p>
-            <code className="block bg-[var(--bg-surface)] text-[var(--accent-cyan)] px-4 py-2.5 rounded-lg font-mono text-sm border border-[var(--border-subtle)]">
-              uvx pramana-ai run --tier cheap --model gpt-4o
-            </code>
+            <span className="flex items-center gap-2 bg-[var(--bg-surface)] rounded-lg border border-[var(--border-subtle)]">
+              <code className="flex-1 text-[var(--accent-cyan)] px-4 py-2.5 font-mono text-sm overflow-x-auto">
+                uvx pramana-ai run --tier cheap --model gpt-4o
+              </code>
+              <CopyButton text="uvx pramana-ai run --tier cheap --model gpt-4o" compact />
+            </span>
           </div>
         )}
 
@@ -277,12 +281,13 @@ export default function Home() {
             Pramana detects LLM drift through crowdsourced output consistency tracking.
             Same prompt + same model + different output = drift detected.
           </p>
-          <p className="text-sm text-[var(--text-secondary)] mb-6">
-            Run evals locally:{' '}
-            <code className="bg-[var(--bg-surface)] text-[var(--accent-cyan)] px-2.5 py-1 rounded-lg font-mono text-xs border border-[var(--border-subtle)]">
+          <p className="text-sm text-[var(--text-secondary)] mb-2">Run evals locally:</p>
+          <span className="flex items-center gap-2 bg-[var(--bg-surface)] rounded-lg border border-[var(--border-subtle)] mb-6">
+            <code className="flex-1 text-[var(--accent-cyan)] px-4 py-2.5 font-mono text-xs overflow-x-auto">
               uvx pramana-ai run --tier cheap --model gpt-4o
             </code>
-          </p>
+            <CopyButton text="uvx pramana-ai run --tier cheap --model gpt-4o" compact />
+          </span>
           <div className="flex flex-wrap gap-3">
             <Button href="/about" variant="secondary" size="md">
               Learn More


### PR DESCRIPTION
## Summary
- Extend `CopyButton` component with a `compact` icon-only variant (clipboard icon → checkmark on click)
- Add copy buttons to both CLI command code blocks on the Home page: the "No data yet" empty state card and the "About Pramana" section

Closes #4

## Test plan
- [ ] Verify the copy icon appears next to the CLI command in the "No data yet" card (clear all data or use empty state)
- [ ] Verify the copy icon appears next to the CLI command in the "About Pramana" section at the bottom
- [ ] Click the copy button — clipboard should contain the full `uvx` command, icon should briefly change to a checkmark
- [ ] Confirm the existing `CopyButton` on the CLI Token page still works as before (no regression)